### PR TITLE
Crud usuarios, loguear usuario, jwt, bcrypt...

### DIFF
--- a/app/controllers/UsuariosController.ts
+++ b/app/controllers/UsuariosController.ts
@@ -1,0 +1,103 @@
+import UsuarioServices from '../services/UsuariosServices.js'
+import type { HttpContext } from '@adonisjs/http-server'
+import bcrypt from 'bcrypt'
+import jwt from 'jsonwebtoken'
+
+const usuarioServices = new UsuarioServices()
+
+export default class UsuariosController {
+  
+  // Login
+ public async login({ request, response }) {
+  try {
+    const { numero_documento, password } = request.body()
+
+    // Validar datos obligatorios
+    if (!numero_documento || !password) {
+      return response.status(400).json({
+        msg: 'El número de documento y la contraseña son obligatorios'
+      })
+    }
+
+    // Buscar usuario por numero_documento (ya modificado en el service)
+    const usuario = await usuarioServices.doc(numero_documento)
+
+    if (!usuario) {
+      return response.status(404).json({ msg: 'Usuario no encontrado' })
+    }
+
+    // Verificar contraseña
+    const validPassword = await bcrypt.compare(password, usuario.password)
+    if (!validPassword) {
+      return response.status(401).json({ msg: 'Contraseña incorrecta' })
+    }
+
+    // Generar token JWT
+    const token = jwt.sign(
+      { id: usuario.id, numero_documento: usuario.numero_documento },
+      process.env.JWT_SECRET || 'clave_secreta',
+      { expiresIn: '1h' }
+    )
+
+    return response.status(200).json({
+      msg: 'Login exitoso',
+      usuario,
+      token
+    })
+
+  } catch (error) {
+    return response.status(500).json({
+      msg: 'Error interno en el login',
+      error: error.message
+    })
+  }
+}
+
+
+  // CRUD
+  public async index({ response }: HttpContext) {
+    try {
+      const usuarios = await usuarioServices.getAll()
+      return response.ok(usuarios)
+    } catch (error) {
+      return response.status(500).json({
+        msj: "No se pudo obtener usuarios",
+        error
+      })
+    }
+  }
+
+  public async show({ params, response }: HttpContext) {
+    const usuario = await usuarioServices.getById(params.id)
+    return response.ok(usuario)
+  }
+
+  public async store({ request, response }: HttpContext) {
+    try {
+      const data = request.body()
+
+      if (!data.numero_documento) {
+        return response.status(400).json({ msg: 'El documento es obligatorio' })
+      }
+      if (!data.password) {
+        return response.status(400).json({ msg: 'La contraseña es obligatoria.' })
+      }
+
+      const usuario = await usuarioServices.create(data)
+      return response.status(201).json({ msg: 'Usuario creado', data: usuario })
+    } catch (e) {
+      return response.status(500).json({ msg: 'Error interno.', error: e.message })
+    }
+  }
+
+  public async update({ params, request, response }: HttpContext) {
+    const data = request.body()
+    const usuario = await usuarioServices.update(params.id, data)
+    return response.ok(usuario)
+  }
+
+  public async destroy({ params, response }: HttpContext) {
+    const result = await usuarioServices.delete(params.id)
+    return response.ok(result)
+  }
+}

--- a/app/models/usuario.ts
+++ b/app/models/usuario.ts
@@ -8,6 +8,10 @@ import Paciente from './paciente.js'
 import Telefono from './telefono.js'
 
 export default class Usuario extends BaseModel {
+  id: any
+  static findOne(arg0: { where: { numero_documento: string } }) {
+    throw new Error('Method not implemented.')
+  }
   @column({ isPrimary: true })
   declare id_usuario: number
 

--- a/app/services/UsuariosServices.ts
+++ b/app/services/UsuariosServices.ts
@@ -1,0 +1,50 @@
+import bcrypt from 'bcrypt'
+import jwt from 'jsonwebtoken'
+import Usuario from '#models/usuario'
+
+export default class UsuarioService {
+  
+  // Métodos CRUD (puedes implementarlos)
+  async getAll() {
+    return await Usuario.all()
+  }
+
+  async getById(id: number) {
+    return await Usuario.findOrFail(id)
+  }
+
+ async doc(numero_documento: string) {
+  return await Usuario
+    .query()
+    .where('numero_documento', numero_documento)
+    .first() // devuelve el primero o null
+}
+
+  async update(id: number, data: any) {
+    const usuario = await Usuario.findOrFail(id)
+    usuario.merge(data)
+    await usuario.save()
+    return usuario
+  }
+
+  async delete(id: number) {
+    const usuario = await Usuario.findOrFail(id)
+    await usuario.delete()
+    return { msg: 'Usuario eliminado' }
+  }
+
+  // Crear usuario
+  public async create(data: any) {
+    try {
+      const hashedPassword = await bcrypt.hash(data.password, 10)
+      data.password = hashedPassword
+      const usuario = await Usuario.create(data)
+      return usuario
+    } catch (error) {
+      console.error('Error al crear el usuario:', error)
+      throw new Error('No se pudo crear el usuario')
+    }
+  }
+
+  
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "@japa/plugin-adonisjs": "^4.0.0",
     "@japa/runner": "^4.2.0",
     "@swc/core": "1.11.24",
+    "@types/bcrypt": "^6.0.0",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/luxon": "^3.7.1",
     "@types/node": "^22.15.18",
     "@types/pg": "^8.15.4",
@@ -53,13 +55,16 @@
   },
   "dependencies": {
     "@adonisjs/auth": "^9.4.0",
-    "@adonisjs/core": "^6.18.0",
+    "@adonisjs/core": "^6.19.0",
     "@adonisjs/cors": "^2.2.1",
     "@adonisjs/lucid": "^21.8.0",
     "@vinejs/vine": "^3.0.1",
+    "bcrypt": "^6.0.0",
+    "jsonwebtoken": "^9.0.2",
     "luxon": "^3.7.1",
     "pg": "^8.16.3",
-    "reflect-metadata": "^0.2.2"
+    "reflect-metadata": "^0.2.2",
+    "uuid": "^11.1.0"
   },
   "hotHook": {
     "boundaries": [

--- a/start/routes/usuarios.ts
+++ b/start/routes/usuarios.ts
@@ -1,0 +1,18 @@
+import UsuariosController from '#controllers/UsuariosController'
+import router from '@adonisjs/core/services/router'
+
+const usuariosController = new UsuariosController()
+
+// Ruta de login independiente
+router.post('/login', async (ctx) => {
+  return usuariosController.login(ctx)
+})
+
+// CRUD Usuarios
+router.group(() => {
+  router.get('/', (ctx) => usuariosController.index(ctx))
+  router.get('/:id', (ctx) => usuariosController.show(ctx))
+  router.post('/', (ctx) => usuariosController.store(ctx))
+  router.put('/:id', (ctx) => usuariosController.update(ctx))
+  router.delete('/:id', (ctx) => usuariosController.destroy(ctx))
+}).prefix('/usuarios')


### PR DESCRIPTION
Cambios...

Implementa login por numero_documento con validación y manejo de errores
Se modificó el método doc en UsuarioService para buscar usuarios por el campo numero_documento en lugar de la clave primaria id, evitando el error "Row not found".
Se actualizó UsuariosController.login para:
Validar que numero_documento y password estén presentes en la solicitud.
Retornar códigos HTTP adecuados (400, 401, 404, 500) según el tipo de error.
Verificar la contraseña usando bcrypt.compare.
Generar y devolver un token JWT válido con expiración de 1 hora.
Se mantuvieron los demás métodos CRUD sin cambios relevantes.

Se instalaron las siguientes dependencias: 
-jwt.
-bcrypt.
-uuid

NOTA: Aplicar proximamente uuid. 

¡GRACIAS!
