### PR TITLE
Usar UUID en id_usuario y corregir modelo Usuario

### DIFF
--- a/app/models/usuario.ts
+++ b/app/models/usuario.ts
@@ -1,4 +1,5 @@
 import { BaseModel, belongsTo, column, hasMany } from '@adonisjs/lucid/orm'
+import { DateTime } from 'luxon'
 import type { TipoDocumento, TipoEstadoCivil, TipoGenero } from '../interfaces/usuarios.js'
 import Ep from './ep.js'
 import type { BelongsTo, HasMany } from '@adonisjs/lucid/types/relations'
@@ -8,12 +9,8 @@ import Paciente from './paciente.js'
 import Telefono from './telefono.js'
 
 export default class Usuario extends BaseModel {
-  id: any
-  static findOne(arg0: { where: { numero_documento: string } }) {
-    throw new Error('Method not implemented.')
-  }
   @column({ isPrimary: true })
-  declare id_usuario: number
+  declare id_usuario: string
 
   @column() declare nombre: string
   @column() declare segundo_nombre: string
@@ -23,9 +20,15 @@ export default class Usuario extends BaseModel {
   @column() declare password: string
   @column() declare direccion: string
   @column() declare numero_documento: string
-  @column() declare fecha_nacimiento: Date
-  @column() declare numero_hijos: number
-  @column() declare estrato: number
+
+  // 👇 Usamos Luxon DateTime
+  @column.date()
+  declare fecha_nacimiento: DateTime
+
+  // 👇 En la base de datos son character varying(2), así que mejor string
+  @column() declare numero_hijos: string
+  @column() declare estrato: string
+
   @column() declare autorizacion_datos: boolean
   @column() declare habilitar: boolean
   @column() declare genero: TipoGenero
@@ -34,18 +37,18 @@ export default class Usuario extends BaseModel {
   @column() declare eps_id: number
   @column() declare rol_id: number
 
-  @belongsTo(()=> Ep, {foreignKey:'eps_id'})
+  @belongsTo(() => Ep, { foreignKey: 'eps_id' })
   declare eps: BelongsTo<typeof Ep>
 
-  @belongsTo(()=> Role, {foreignKey:'rol_id'})
+  @belongsTo(() => Role, { foreignKey: 'rol_id' })
   declare rol: BelongsTo<typeof Role>
 
-  @hasMany(()=> Medico)
+  @hasMany(() => Medico)
   declare medicos: HasMany<typeof Medico>
 
-  @hasMany(()=> Paciente)
+  @hasMany(() => Paciente)
   declare pacientes: HasMany<typeof Paciente>
 
-  @hasMany(()=> Telefono)
+  @hasMany(() => Telefono)
   declare telefonos: HasMany<typeof Telefono>
 }

--- a/app/services/UsuariosServices.ts
+++ b/app/services/UsuariosServices.ts
@@ -1,10 +1,10 @@
 import bcrypt from 'bcrypt'
-import jwt from 'jsonwebtoken'
+import { v4 as uuidv4 } from 'uuid' 
 import Usuario from '#models/usuario'
 
 export default class UsuarioService {
   
-  // Métodos CRUD (puedes implementarlos)
+  // Métodos CRUD 
   async getAll() {
     return await Usuario.all()
   }
@@ -13,12 +13,12 @@ export default class UsuarioService {
     return await Usuario.findOrFail(id)
   }
 
- async doc(numero_documento: string) {
-  return await Usuario
-    .query()
-    .where('numero_documento', numero_documento)
-    .first() // devuelve el primero o null
-}
+  async doc(numero_documento: string) {
+    return await Usuario
+      .query()
+      .where('numero_documento', numero_documento)
+      .first() 
+  }
 
   async update(id: number, data: any) {
     const usuario = await Usuario.findOrFail(id)
@@ -34,17 +34,22 @@ export default class UsuarioService {
   }
 
   // Crear usuario
-  public async create(data: any) {
-    try {
-      const hashedPassword = await bcrypt.hash(data.password, 10)
-      data.password = hashedPassword
-      const usuario = await Usuario.create(data)
-      return usuario
-    } catch (error) {
-      console.error('Error al crear el usuario:', error)
-      throw new Error('No se pudo crear el usuario')
-    }
-  }
+public async create(data: any) {
+  try {
+    // Generar UUID
+    data.id_usuario = uuidv4()   // 👈 importante: coincide con tu tabla
 
-  
+    // Hashear contraseña
+    const hashedPassword = await bcrypt.hash(data.password, 10)
+    data.password = hashedPassword
+
+    // Crear usuario
+    const usuario = await Usuario.create(data)
+    return usuario
+  } catch (error) {
+    console.error('Error al crear el usuario:', error)
+    throw new Error('No se pudo crear el usuario')
+  }
+}
+
 }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@adonisjs/cors": "^2.2.1",
     "@adonisjs/lucid": "^21.8.0",
     "@vinejs/vine": "^3.0.1",
+    "axios": "^1.11.0",
     "bcrypt": "^6.0.0",
     "jsonwebtoken": "^9.0.2",
     "luxon": "^3.7.1",


### PR DESCRIPTION
Se instalo Axios...

Se implementó el uso de UUID v4 como clave primaria (id_usuario) en la tabla de usuarios. Para ello se ajustó el servicio de creación de usuarios para generar el UUID automáticamente y se corrigió el modelo Usuario.ts en AdonisJS, definiendo correctamente id_usuario como primary key y ajustando los tipos de datos (ej. fecha_nacimiento con DateTime, estrato y numero_hijos como string). Con esto, los usuarios ahora se registran con identificadores únicos y compatibles con la base de datos.