### PR TITLE
fix-prefrix-medico-routes

### DIFF
--- a/start/routes/medicos.ts
+++ b/start/routes/medicos.ts
@@ -16,6 +16,6 @@ router.group(() => {
   
   // Ruta especial para cambiar disponibilidad (me la dio chat)
   router.patch('/:id/disponibilidad', [MedicosController, 'cambiarDisponibilidad'])
-}).prefix('/medicos')
+}).prefix('medicos')
 
 export default router


### PR DESCRIPTION
se elimina '/' del prefix de las rutas de medicos para que no interfiera con la url del login