### PR TITLE
Ruta Asociar Beneficiario a Titular

### DIFF
--- a/app/controllers/PacientesController.ts
+++ b/app/controllers/PacientesController.ts
@@ -36,13 +36,11 @@ export default class PacientesController {
       } = request.body()
 
       const userExist = await paciente.readByDoc(numero_documento)
-
       if (userExist) {
         return response.status(500).json({ message: 'El usuario ya se encuentra registrado' })
       }
 
       const hash = await bcrypt.hash(password, 10)
-
       const newPaciente = await paciente.create(
         {
           direccion_cobro,
@@ -79,6 +77,7 @@ export default class PacientesController {
       return response.status(500).json({ message: 'Error', error: e.message })
     }
   }
+
   async readAll({ response }: HttpContext) {
     try {
       const users = await paciente.read()
@@ -87,6 +86,7 @@ export default class PacientesController {
       return response.status(500).json({ message: 'Error', error: e.message })
     }
   }
+
   async readById({ params, response }: HttpContext) {
     try {
       const { id } = params
@@ -96,7 +96,8 @@ export default class PacientesController {
       return response.status(500).json({ message: 'Error', error: e.message })
     }
   }
-  async readByITitular({  response }: HttpContext) {
+
+  async readByITitular({ response }: HttpContext) {
     try {
       const userTi = await paciente.readByTitular()
       return response.status(200).json({ message: 'Información obtenida', data: userTi })
@@ -104,6 +105,7 @@ export default class PacientesController {
       return response.status(500).json({ message: 'Error', error: e.message })
     }
   }
+
   async deleteById({ params, response }: HttpContext) {
     try {
       const { id } = params
@@ -113,6 +115,7 @@ export default class PacientesController {
       return response.status(500).json({ message: 'Error', error: e.message })
     }
   }
+
   async updateById({ params, request, response }: HttpContext) {
     try {
       const { id } = params
@@ -178,10 +181,9 @@ export default class PacientesController {
       return response.status(500).json({ message: 'Error', error: e.message })
     }
   }
-  
+
   async readByUsuarioLogueado({ request, response }: HttpContext) {
     try {
-      // 👇 Forzamos auth como any para evitar error TS
       const auth: any = (request as any).auth
 
       if (!auth) {
@@ -209,5 +211,85 @@ export default class PacientesController {
       return response.status(500).json({ message: 'Error', error: e.message })
     }
   }
-}
 
+  // 🔹 Nuevo método: crear beneficiario asociado a un titular
+  async addBeneficiario({ params, request, response }: HttpContext) {
+    try {
+      const { id_titular } = params
+      const {
+        nombre,
+        segundo_nombre,
+        apellido,
+        segundo_apellido,
+        email,
+        password,
+        direccion,
+        numero_documento,
+        fecha_nacimiento,
+        numero_hijos,
+        estrato,
+        autorizacion_datos,
+        habilitar,
+        genero,
+        estado_civil,
+        tipo_documento,
+        eps_id,
+        rol_id,
+        direccion_cobro,
+        ocupacion,
+        activo,
+      } = request.body()
+
+      const id_usuario = uuidv4()
+      const hash = await bcrypt.hash(password, 10)
+
+      const beneficiario = await paciente.addBeneficiario(
+        Number(id_titular),
+        {
+          direccion_cobro,
+          ocupacion,
+          activo,
+          beneficiario: true,
+          paciente_id: Number(id_titular),
+          usuario_id: id_usuario,
+        },
+        {
+          id_usuario,
+          nombre,
+          segundo_nombre,
+          apellido,
+          segundo_apellido,
+          email,
+          password: hash,
+          direccion,
+          numero_documento,
+          fecha_nacimiento,
+          numero_hijos,
+          estrato,
+          autorizacion_datos,
+          habilitar,
+          genero,
+          estado_civil,
+          tipo_documento,
+          eps_id,
+          rol_id,
+        }
+      )
+
+      return response.status(201).json({ message: 'Beneficiario creado', data: beneficiario })
+    } catch (e) {
+      return response.status(500).json({ message: 'Error', error: e.message })
+    }
+  }
+
+  // 🔹 Nuevo método: obtener beneficiarios por titular
+  async readBeneficiariosByTitular({ params, response }: HttpContext) {
+    try {
+      const { id_titular } = params
+      const beneficiarios = await paciente.getBeneficiariosByTitular(Number(id_titular))
+      return response.status(200).json({ message: 'Beneficiarios obtenidos', data: beneficiarios })
+    } catch (e) {
+      return response.status(500).json({ message: 'Error', error: e.message })
+    }
+  }
+}

--- a/app/interfaces/beneficiarios.ts
+++ b/app/interfaces/beneficiarios.ts
@@ -1,0 +1,8 @@
+export interface DataBeneficiario {
+  direccion_cobro: string
+  ocupacion: string
+  activo: boolean
+  beneficiario: boolean
+  usuario_id?: string
+  paciente_id: number  // titular
+}

--- a/app/services/PacientesServices.ts
+++ b/app/services/PacientesServices.ts
@@ -14,23 +14,34 @@ export default class PacientesServices {
       return newUser
     } catch (e) {
       await trx.rollback()
-      throw new Error(`Error al crear las dos registros ${e.message}`)
+      throw new Error(`Error al crear los dos registros: ${e.message}`)
     }
   }
+
   async read() {
     return await Paciente.query().preload('usuario')
   }
+
   async readByTitular() {
-    return await Paciente.query().preload('usuario').whereNull('paciente_id').has('membresiaPaciente').preload('membresiaPaciente', (mxpQuery)=>{mxpQuery.preload('membresia')})
+    return await Paciente.query()
+      .preload('usuario')
+      .whereNull('paciente_id')
+      .has('membresiaPaciente')
+      .preload('membresiaPaciente', (mxpQuery) => {
+        mxpQuery.preload('membresia')
+      })
   }
+
   async readByDoc(doc: string) {
     const pac = await Usuario.query().where('numero_documento', doc).first()
     return pac
   }
+
   async readById(id: number) {
     const pac = await Paciente.query().preload('usuario').where('id_paciente', id).first()
     return pac
   }
+
   async delete(id: number) {
     const trx = await db.transaction()
     try {
@@ -44,28 +55,65 @@ export default class PacientesServices {
       return { pac, user }
     } catch (e) {
       await trx.rollback()
-      throw new Error(`Error al eliminar los registros ${e.message}`)
+      throw new Error(`Error al eliminar los registros: ${e.message}`)
     }
   }
+
   async update(id: number, data: DataPaciente, userD: DataUsuario) {
     const trx = await db.transaction()
     try {
       const pac = await Paciente.findOrFail(id, { client: trx })
       const iduser = pac.usuario_id
       const user = await Usuario.findOrFail(iduser, { client: trx })
+
       pac.useTransaction(trx).merge(data)
       await pac.save()
+
       user.useTransaction(trx).merge(userD)
       await user.save()
+
       await trx.commit()
       return { pac, user }
     } catch (e) {
       await trx.rollback()
-      throw new Error(`Error al eliminar los registros ${e.message}`)
+      throw new Error(`Error al actualizar los registros: ${e.message}`)
     }
   }
-    async readByUsuarioId(usuarioId: string) {
+
+  async readByUsuarioId(usuarioId: string) {
     return await Paciente.query().where('usuario_id', usuarioId).first()
   }
-}
 
+  // 🔹 Nuevo método para agregar beneficiarios
+  async addBeneficiario(titularId: number, data: DataPaciente, user: DataUsuario) {
+    const trx = await db.transaction()
+    try {
+      const titular = await Paciente.findOrFail(titularId, { client: trx })
+
+      // Crear usuario del beneficiario
+      await Usuario.create(user, { client: trx })
+
+      const beneficiario = await Paciente.create(
+        {
+          ...data,
+          beneficiario: true,
+          paciente_id: titular.id_paciente,
+        },
+        { client: trx }
+      )
+
+      await trx.commit()
+      return beneficiario
+    } catch (e) {
+      await trx.rollback()
+      throw new Error(`Error al crear beneficiario: ${e.message}`)
+    }
+  }
+
+  // 🔹 Nuevo método para obtener beneficiarios por titular
+  async getBeneficiariosByTitular(titularId: number) {
+    return await Paciente.query()
+      .where('paciente_id', titularId)
+      .preload('usuario')
+  }
+}

--- a/start/routes/pacientes.ts
+++ b/start/routes/pacientes.ts
@@ -11,3 +11,5 @@ router.get('/pacientes/:id', paciente.readById);
 router.delete('/pacientes/:id', paciente.deleteById);
 router.put('/pacientes/:id', paciente.updateById);
 router.get('/pacientes/mi-perfil', paciente.readByUsuarioLogueado);
+router.post('/pacientes/:id_titular/beneficiarios', paciente.addBeneficiario);
+router.get('/pacientes/:id_titular/beneficiarios', paciente.readBeneficiariosByTitular);


### PR DESCRIPTION
feat(pacientes): implementación de relación titular-beneficiario

- Se añadieron nuevas rutas para vincular beneficiarios a un titular:
  • POST /pacientes/:id_titular/beneficiarios → crea un beneficiario asociado al titular.
  • GET /pacientes/:id_titular/beneficiarios → obtiene los beneficiarios del titular.
- Se actualizó el controller y el service de Pacientes para manejar la relación.
- Se permite que cada beneficiario esté vinculado a un titular mediante el campo paciente_id.

